### PR TITLE
Pin Node.js version to 24.x for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   ],
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev0": "cross-env NODE_OPTIONS='--inspect' next dev",
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Vercel deploys were failing with `Found invalid or discontinued Node.js Version: "18.x"`
- Added an `engines.node: "24.x"` field to `package.json` so Vercel picks up the correct Node version for builds

## Why
Vercel no longer exposes a Node.js Version dropdown under Project Settings → General for this project; it now appears to source the Node version from `package.json`'s `engines` field instead.

## Test plan
- [ ] Merge and confirm the next Vercel deployment builds successfully on Node 24.x