### PR TITLE
Fix playground top padding from .container class collision

### DIFF
--- a/public/demos/1.html
+++ b/public/demos/1.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/10.html
+++ b/public/demos/10.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -152,7 +152,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/100.html
+++ b/public/demos/100.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/101.html
+++ b/public/demos/101.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/102.html
+++ b/public/demos/102.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/103.html
+++ b/public/demos/103.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/104.html
+++ b/public/demos/104.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/105.html
+++ b/public/demos/105.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -146,7 +146,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/106.html
+++ b/public/demos/106.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/107.html
+++ b/public/demos/107.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/108.html
+++ b/public/demos/108.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/109.html
+++ b/public/demos/109.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/11.html
+++ b/public/demos/11.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -153,7 +153,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/110.html
+++ b/public/demos/110.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/111.html
+++ b/public/demos/111.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/112.html
+++ b/public/demos/112.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/113.html
+++ b/public/demos/113.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/114.html
+++ b/public/demos/114.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/115.html
+++ b/public/demos/115.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/116.html
+++ b/public/demos/116.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/117.html
+++ b/public/demos/117.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/118.html
+++ b/public/demos/118.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/119.html
+++ b/public/demos/119.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/12.html
+++ b/public/demos/12.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -153,7 +153,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/120.html
+++ b/public/demos/120.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/121.html
+++ b/public/demos/121.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/122.html
+++ b/public/demos/122.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/123.html
+++ b/public/demos/123.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/124.html
+++ b/public/demos/124.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -146,7 +146,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/125.html
+++ b/public/demos/125.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/126.html
+++ b/public/demos/126.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/127.html
+++ b/public/demos/127.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/128.html
+++ b/public/demos/128.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/129.html
+++ b/public/demos/129.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/13.html
+++ b/public/demos/13.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -148,7 +148,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/130.html
+++ b/public/demos/130.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -142,7 +142,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/131.html
+++ b/public/demos/131.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/132.html
+++ b/public/demos/132.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/133.html
+++ b/public/demos/133.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/134.html
+++ b/public/demos/134.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/135.html
+++ b/public/demos/135.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/136.html
+++ b/public/demos/136.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/137.html
+++ b/public/demos/137.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/138.html
+++ b/public/demos/138.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/139.html
+++ b/public/demos/139.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/14.html
+++ b/public/demos/14.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -154,7 +154,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/140.html
+++ b/public/demos/140.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/141.html
+++ b/public/demos/141.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/142.html
+++ b/public/demos/142.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/143.html
+++ b/public/demos/143.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/144.html
+++ b/public/demos/144.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/145.html
+++ b/public/demos/145.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/146.html
+++ b/public/demos/146.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/147.html
+++ b/public/demos/147.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/148.html
+++ b/public/demos/148.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/149.html
+++ b/public/demos/149.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -159,7 +159,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/15.html
+++ b/public/demos/15.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -155,7 +155,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/16.html
+++ b/public/demos/16.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -153,7 +153,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/17.html
+++ b/public/demos/17.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -152,7 +152,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/18.html
+++ b/public/demos/18.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -148,7 +148,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/19.html
+++ b/public/demos/19.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -152,7 +152,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/2.html
+++ b/public/demos/2.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -148,7 +148,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/20.html
+++ b/public/demos/20.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/21.html
+++ b/public/demos/21.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/22.html
+++ b/public/demos/22.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/23.html
+++ b/public/demos/23.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/24.html
+++ b/public/demos/24.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/25.html
+++ b/public/demos/25.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -146,7 +146,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/26.html
+++ b/public/demos/26.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/27.html
+++ b/public/demos/27.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/28.html
+++ b/public/demos/28.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/29.html
+++ b/public/demos/29.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/3.html
+++ b/public/demos/3.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/30.html
+++ b/public/demos/30.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -146,7 +146,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/31.html
+++ b/public/demos/31.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/32.html
+++ b/public/demos/32.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/33.html
+++ b/public/demos/33.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/34.html
+++ b/public/demos/34.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/35.html
+++ b/public/demos/35.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/36.html
+++ b/public/demos/36.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/37.html
+++ b/public/demos/37.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/38.html
+++ b/public/demos/38.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/39.html
+++ b/public/demos/39.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/4.html
+++ b/public/demos/4.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/40.html
+++ b/public/demos/40.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/41.html
+++ b/public/demos/41.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/42.html
+++ b/public/demos/42.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/43.html
+++ b/public/demos/43.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/44.html
+++ b/public/demos/44.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/45.html
+++ b/public/demos/45.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/46.html
+++ b/public/demos/46.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/47.html
+++ b/public/demos/47.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/48.html
+++ b/public/demos/48.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/49.html
+++ b/public/demos/49.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/5.html
+++ b/public/demos/5.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/50.html
+++ b/public/demos/50.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/51.html
+++ b/public/demos/51.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/52.html
+++ b/public/demos/52.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/53.html
+++ b/public/demos/53.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/54.html
+++ b/public/demos/54.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/55.html
+++ b/public/demos/55.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/56.html
+++ b/public/demos/56.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/57.html
+++ b/public/demos/57.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/58.html
+++ b/public/demos/58.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/59.html
+++ b/public/demos/59.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -144,7 +144,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/6.html
+++ b/public/demos/6.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -152,7 +152,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/60.html
+++ b/public/demos/60.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/61.html
+++ b/public/demos/61.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/62.html
+++ b/public/demos/62.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/63.html
+++ b/public/demos/63.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/64.html
+++ b/public/demos/64.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/65.html
+++ b/public/demos/65.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/66.html
+++ b/public/demos/66.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/67.html
+++ b/public/demos/67.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/68.html
+++ b/public/demos/68.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/69.html
+++ b/public/demos/69.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/7.html
+++ b/public/demos/7.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/70.html
+++ b/public/demos/70.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/71.html
+++ b/public/demos/71.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/72.html
+++ b/public/demos/72.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/73.html
+++ b/public/demos/73.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/74.html
+++ b/public/demos/74.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/75.html
+++ b/public/demos/75.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/76.html
+++ b/public/demos/76.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/77.html
+++ b/public/demos/77.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/78.html
+++ b/public/demos/78.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/79.html
+++ b/public/demos/79.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/8.html
+++ b/public/demos/8.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -152,7 +152,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/80.html
+++ b/public/demos/80.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/81.html
+++ b/public/demos/81.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -145,7 +145,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/82.html
+++ b/public/demos/82.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -143,7 +143,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/83.html
+++ b/public/demos/83.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/84.html
+++ b/public/demos/84.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/85.html
+++ b/public/demos/85.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/86.html
+++ b/public/demos/86.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/87.html
+++ b/public/demos/87.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/88.html
+++ b/public/demos/88.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/89.html
+++ b/public/demos/89.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/9.html
+++ b/public/demos/9.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/90.html
+++ b/public/demos/90.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/91.html
+++ b/public/demos/91.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/92.html
+++ b/public/demos/92.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/93.html
+++ b/public/demos/93.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/94.html
+++ b/public/demos/94.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/95.html
+++ b/public/demos/95.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/96.html
+++ b/public/demos/96.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -146,7 +146,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/97.html
+++ b/public/demos/97.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/98.html
+++ b/public/demos/98.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>

--- a/public/demos/99.html
+++ b/public/demos/99.html
@@ -13,7 +13,7 @@
     }
     
     /* Layout */
-    .container {
+    .playground-container {
       display: flex;
       justify-content: space-between;
       padding: 20px;
@@ -141,7 +141,7 @@
   </script>
 </head>
 <body>
-  <div class="container">
+  <div class="playground-container">
     <div class="code-panel">
       <div class="tabs">
         <button id="html-tab" class="tab" onclick="switchTab('html')">HTML</button>


### PR DESCRIPTION
## Summary
- The most recent post (`font-weight`) rendered with a ~50px gap between the post card and the playground UI (HTML/CSS/JS tabs + preview).
- Root cause: every demo page in `public/demos/{N}.html` wraps its playground UI in a structural `<div class="container">` with a matching CSS rule. When a post's own AI-generated demo CSS also defines a `.container` class (a common convention for centering demo content — e.g. `font-weight`'s demo used `.container { text-align: center; margin-top: 50px; }`), that rule collides with the template's own selector in the same stylesheet, leaking `margin-top: 50px` onto the outer structural wrapper instead of just the intended preview content.
- Renamed the template's structural wrapper class to `.playground-container` (in the sibling `ai-blogger-agent` repo's `demoTemplateGenerator.ts`, so future posts aren't affected) and applied the same rename across all 149 existing `public/demos/*.html` files, since 7 other posts (4, 34, 94, 110, 111, 125, 129) had the same latent collision.

## Test plan
- [x] Confirmed the bug reproduces on the pre-fix `149.html` in a browser (playground pushed down ~50px, matching the reported screenshot)
- [x] Confirmed the fixed `149.html` renders with the playground flush at the top (only the intended 20px padding)
- [x] Verified all 149 demo files got exactly one rename of the CSS selector and one rename of the wrapper `div`, with no other content touched